### PR TITLE
Set current window location scheme if available

### DIFF
--- a/v3/index.tpl.go
+++ b/v3/index.tpl.go
@@ -65,7 +65,17 @@ var indexTpl = `
             layout: "StandaloneLayout",
             showExtensions: true,
             showCommonExtensions: true,
-            validatorUrl: null
+            validatorUrl: null,
+			onComplete: function() {
+				var dom = document.querySelector('.scheme-container select');
+				for (var key in dom) {
+					if (key.startsWith("__reactInternalInstance$")) {
+						var compInternals = dom[key]._currentElement;
+						var compWrapper = compInternals._owner;
+						compWrapper._instance.setScheme(window.location.protocol.slice(0,-1));
+					}
+				}
+			}
         };
 
         if (cfg.preAuthorizeApiKey) {


### PR DESCRIPTION
This PR workarounds the issue https://github.com/swagger-api/swagger-ui/issues/1382 to pick window location scheme by default.