### PR TITLE
Remove go version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,3 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190830172400-56125e7d709e // indirect
 )
-
-go 1.11


### PR DESCRIPTION
In order to maintain backwards build compatibility with applications built with older versions of Go this PR removes `go 1.11` statement from `go.mod` until `go1.16` becomes minimal supported version of `Go`.

See https://github.com/golang/go/issues/43980 for relevant discussion.