### PR TITLE
add internal basepath

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,10 @@ type Config struct {
 	SwaggerJSON string `json:"swaggerJsonUrl"` // URL to openapi.json/swagger.json document specification.
 	BasePath    string `json:"basePath"`       // Base URL to docs.
 
+	// InternalBasePath is used to override BasePath if external
+	// url differs from internal one.
+	InternalBasePath string `json:"-"`
+
 	ShowTopBar         bool              `json:"showTopBar"`         // Show navigation top bar, hidden by default.
 	HideCurl           bool              `json:"hideCurl"`           // Hide curl code snippet.
 	JsonEditor         bool              `json:"jsonEditor"`         // Enable visual json editor support (experimental, can fail with complex schemas).

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -28,6 +28,11 @@ func NewHandlerWithConfig(config swgui.Config, assetsBase, faviconBase string, s
 		Config: config,
 	}
 
+	if h.InternalBasePath == "" {
+		h.InternalBasePath = h.BasePath
+	}
+	h.InternalBasePath = strings.TrimSuffix(h.InternalBasePath, "/") + "/"
+
 	j, err := json.Marshal(h.Config)
 	if err != nil {
 		panic(err)
@@ -41,7 +46,7 @@ func NewHandlerWithConfig(config swgui.Config, assetsBase, faviconBase string, s
 	}
 
 	if staticServer != nil {
-		h.staticServer = http.StripPrefix(h.BasePath, staticServer)
+		h.staticServer = http.StripPrefix(h.InternalBasePath, staticServer)
 	}
 
 	return h
@@ -49,7 +54,7 @@ func NewHandlerWithConfig(config swgui.Config, assetsBase, faviconBase string, s
 
 // ServeHTTP implements http.Handler interface to handle swagger UI request.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if strings.TrimSuffix(r.URL.Path, "/") != strings.TrimSuffix(h.BasePath, "/") && h.staticServer != nil {
+	if strings.TrimSuffix(r.URL.Path, "/") != strings.TrimSuffix(h.InternalBasePath, "/") && h.staticServer != nil {
 		h.staticServer.ServeHTTP(w, r)
 
 		return

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -31,6 +31,7 @@ func NewHandlerWithConfig(config swgui.Config, assetsBase, faviconBase string, s
 	if h.InternalBasePath == "" {
 		h.InternalBasePath = h.BasePath
 	}
+
 	h.InternalBasePath = strings.TrimSuffix(h.InternalBasePath, "/") + "/"
 
 	j, err := json.Marshal(h.Config)


### PR DESCRIPTION
Adds an internal BasePath to swgui.Config so that internal and external BasePaths can differ (which can be the case when the apps stands behind a reverse proxy)

Example of such configuration:

```golang
v5emb.NewHandlerWithConfig(swgui.Config{
		BasePath:         "/myapp/swagger/ui/",
		Title:            "MyApp API",
		InternalBasePath: "/swagger/ui/",
		SwaggerJSON:      "/myapp/myapp.openapi.yml",
	})
```
