### PR TITLE
Handle relative swaggerJsonUrl's

### DIFF
--- a/internal/index.tpl.go
+++ b/internal/index.tpl.go
@@ -95,7 +95,13 @@ func IndexTpl(assetsBase, faviconBase string, cfg swgui.Config) string {
         var cfg = {{ .ConfigJson }};
         var url = cfg.swaggerJsonUrl;
         if (!url.startsWith("https://") && !url.startsWith("http://")) {
-           url = window.location.protocol + "//" + window.location.host + url;
+            if (url.startsWith(".")) {
+                var path = window.location.pathname;
+                path = path.endsWith("/") ? path : path + "/";
+                url = window.location.protocol + "//" + window.location.host + path + url;
+            } else {
+                url = window.location.protocol + "//" + window.location.host + url;
+            }
         }
 
         // Build a system


### PR DESCRIPTION
To support relative jsonSwaggerUrl's we need to add the pathname as well.